### PR TITLE
Modify ExpenseCategory with nested enums

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,14 @@
 		<java.version>24</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/src/main/java/com/example/expense_checker/enums/ExpenseCategory.java
+++ b/src/main/java/com/example/expense_checker/enums/ExpenseCategory.java
@@ -1,0 +1,31 @@
+package com.example.expense_checker.enums;
+
+public enum ExpenseCategory {
+    UTILITY,
+    FOOD,
+    COMODITY,
+    SERVICE,
+    EDUCATION,
+    MEDICAL,
+    LEISURE_TRAVEL,
+    OTHER;
+
+    public enum CommoditySubCategory {
+        COSMETICS,
+        HOUSING_CLEANING,
+        HOUSING_STORAGE,
+        CLOTHE
+    }
+
+    public enum FoodSubCategory {
+        SNACK,
+        VEGETABLE,
+        FISH
+    }
+
+    public enum LeisureSubCategory {
+        TRAVEL_TRANSPORTATION,
+        HOTEL,
+        DINE_OUT
+    }
+}

--- a/src/main/java/com/example/expense_checker/enums/PaymentType.java
+++ b/src/main/java/com/example/expense_checker/enums/PaymentType.java
@@ -1,0 +1,11 @@
+package com.example.expense_checker.enums;
+
+/**
+ * Represents payment method recorded in the CSV.
+ * Actual values may vary depending on PayPay export.
+ */
+public enum PaymentType {
+    CREDIT_CARD,
+    PAYPAY_BALANCE,
+    OTHER
+}

--- a/src/main/java/com/example/expense_checker/model/Expense.java
+++ b/src/main/java/com/example/expense_checker/model/Expense.java
@@ -1,0 +1,43 @@
+package com.example.expense_checker.model;
+
+import com.example.expense_checker.enums.ExpenseCategory;
+import com.example.expense_checker.enums.PaymentType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+
+@Data
+@Entity
+public class Expense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private LocalDate date;
+
+    @NotNull
+    private String merchant;
+
+    @NotNull
+    @Positive
+    private BigDecimal amount;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private PaymentType paymentType;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "expense_categories", joinColumns = @JoinColumn(name = "expense_id"))
+    @Column(name = "category")
+    private Set<@NotNull ExpenseCategory> categories;
+
+    private String eventName;
+}

--- a/src/main/java/com/example/expense_checker/repository/ExpenseRepository.java
+++ b/src/main/java/com/example/expense_checker/repository/ExpenseRepository.java
@@ -1,0 +1,13 @@
+package com.example.expense_checker.repository;
+
+import com.example.expense_checker.enums.ExpenseCategory;
+import com.example.expense_checker.model.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    List<Expense> findByDateBetween(LocalDate start, LocalDate end);
+    List<Expense> findByCategoriesContaining(ExpenseCategory category);
+}


### PR DESCRIPTION
##  Prompty
- prompt : Create Expense entity with multi-category support and repository


Create a JPA entity class named Expense for a household expense tracker application. This will be used to import and analyze PayPay credit card CSV data.
Use the actual data structure from the uploaded PayPay monthly CSV (e.g., "利用日", "ご利用店名", "利用金額", "利用区分", "明細区分").

📄 Entity Requirements:
Field name	Type	Notes
id	Long	@Id, auto-generated
date	LocalDate	From CSV field: "利用日"
merchant	String	From: "ご利用店名"
amount	BigDecimal	From: "利用金額"
paymentTyoe	Enum	From: "決済方法"
categories	Set<ExpenseCategory>	A set of one or more categories applied to this expense
eventName	String	Optional, used to annotate special events (e.g., "音楽フェス")

Use @ElementCollection to persist the set of ExpenseCategory enums.

Use @Enumerated(EnumType.STRING) for the enum values.

Use validation annotations (@NotNull, @Positive, etc.) where applicable.

Use Lombok annotations if available, or generate getters/setters.

---
second prompt  : 
I cahnged my mind 
can you create nested Enum ? 

ExpenseCategory {
  UTILITY,
  FOOD,
  COMODITY,
  SERVICE,
  EDUCATION,
  MEDICAL,
  LEISURE_TRAVEL,
  OTHER
}

THEN for COMODITY , 
there is subtype like COSMETICS, HOUSING=CLEANING,HOUSEING_STORAGE,
CLOTHE...etc 

for FOOD subtye is SNACK, VEGETABLE,FISH ...

for LEISURE
it has trave_transportation , hotel, diningout


can you modifty the enum
